### PR TITLE
Update README with extra requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ The cursors can also be found under dist/ directory. Copy them to ~/.icons/ (onl
     - make
     - inkscape
     - xcursorgen
+    - ruby
+    - boost-libs/libboost-dev
 
 2. Run the following commands as normal user:
 


### PR DESCRIPTION
Running the manual install on Arch, I realised it requires Ruby and libboost libraries to `make build`. Without these, build fails. It is fair to update the README