### PR TITLE
fix issue#30

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,6 +6,7 @@
 
 set -e
 
+DBUS_SESSION_BUS_ADDRESS=""
 INKSCAPE_VERSION=$(inkscape --version 2>/dev/null | awk '/Inkscape[ ]/ {print $2; exit}')
 
 convert_to_png() {


### PR DESCRIPTION
currently running `sudo make install` fails with the following output, as reported by many users:
```
bash build.sh
=> Workon './src/oreo_black_cursors' ...
terminate called after throwing an instance of 'Gio::DBus::Error'
terminate called after throwing an instance of 'Gio::DBus::Error'
xargs: sh: terminated by signal 6
xargs: sh: terminated by signal 6
make: *** [Makefile:7: build] Error 125
```

This commit suggested by @JefteKeller [here](https://github.com/varlesh/oreo-cursors/issues/30#issuecomment-2198390093) fixes the issue.